### PR TITLE
Persistent certificate cache for Caddy

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -23,9 +23,8 @@ RUN docker-php-ext-install \
 
 RUN echo 'memory_limit = 512M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;
 # Set location for Caddy configuration and data
-ENV XDG_CONFIG_HOME /config
-
-ENV XDG_DATA_HOME /data
+ENV XDG_CONFIG_HOME=/config \
+    XDG_DATA_HOME=/data
 
 EXPOSE 80 443
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -22,6 +22,10 @@ RUN docker-php-ext-install \
     opcache
 
 RUN echo 'memory_limit = 512M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;
+# Set location for Caddy configuration and data
+ENV XDG_CONFIG_HOME /config
+
+ENV XDG_DATA_HOME /data
 
 EXPOSE 80 443
 

--- a/src/docker-compose.dev.yaml
+++ b/src/docker-compose.dev.yaml
@@ -9,6 +9,8 @@ services:
       - "8443:443"
     volumes:
       - ./prestashop:/app/prestashop
+      - caddy-data:/data/caddy
+      - caddy-config:/config/caddy
     environment:
       DB_HOST: prestashop-db
       DB_NAME: ${MARIADB_DATABASE}
@@ -55,3 +57,5 @@ services:
 
 volumes:
   prestashop-db-data:
+  caddy-data:
+  caddy-config:

--- a/src/docker-compose.yaml
+++ b/src/docker-compose.yaml
@@ -7,6 +7,9 @@ services:
     ports:
       - "8080:80"
       - "8443:443"
+    volumes:
+      - caddy-data:/data/caddy
+      - caddy-config:/config/caddy
     environment:
       DB_HOST: prestashop-db
       DB_NAME: ${MARIADB_DATABASE}
@@ -34,3 +37,5 @@ services:
 
 volumes:
   prestashop-db-data:
+  caddy-data:
+  caddy-config:


### PR DESCRIPTION
- Move Caddy `config` and `data` directories to the volumes - now the certificate should be restored after restating the container.

Closes #6 